### PR TITLE
Fix/461 safari date fromat issue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -694,7 +694,7 @@ include(<span class="hljs-string">'error message'</span>, [<span class="hljs-str
 <span class="hljs-comment">// ISO strings</span>
 date(<span class="hljs-string">'error message'</span>, <span class="hljs-string">'2000-12-30'</span>, <span class="hljs-string">'2020-06-29'</span>);
 <span class="hljs-comment">// Date objects</span>
-date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2000-12-30T00:00:00+0000'</span>), <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2020-06-29T00:00:00+0000'</span>));
+date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2000-12-30T00:00:00+00:00'</span>), <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2020-06-29T00:00:00+00:00'</span>));
 
 <span class="hljs-comment">/**
  * The value (date) must after the date.
@@ -702,7 +702,7 @@ date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword
 <span class="hljs-comment">// ISO string</span>
 date(<span class="hljs-string">'error message'</span>, <span class="hljs-string">'2000-12-30'</span>);
 <span class="hljs-comment">// Date object</span>
-date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2000-12-30T00:00:00+0000'</span>))
+date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2000-12-30T00:00:00+00:00'</span>))
 
 <span class="hljs-comment">/**
  * The value (date) must before the date.
@@ -710,7 +710,7 @@ date(<span class="hljs-string">'error message'</span>, <span class="hljs-keyword
 <span class="hljs-comment">// ISO string</span>
 date(<span class="hljs-string">'error message'</span>, <span class="hljs-literal">undefined</span>|<span class="hljs-literal">null</span>, <span class="hljs-string">'2020-06-29'</span>);
 <span class="hljs-comment">// Date object</span>
-date(<span class="hljs-string">'error message'</span>, <span class="hljs-literal">undefined</span>|<span class="hljs-literal">null</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2020-06-29T00:00:00+0000'</span>))
+date(<span class="hljs-string">'error message'</span>, <span class="hljs-literal">undefined</span>|<span class="hljs-literal">null</span>, <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>(<span class="hljs-string">'2020-06-29T00:00:00+00:00'</span>))
 
 <span class="hljs-comment">/**
  * Relative offsets, relative to today.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/wegood",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Tiny validation library, so wegood with data.",
   "main": "lib/wegood.js",
   "module": "lib/wegood.esm.js",

--- a/readme.md
+++ b/readme.md
@@ -468,7 +468,7 @@ Instead of a concrete ISO date string or Date object below annotated shortcodes 
 // ISO strings
 date('error message', '2000-12-30', '2020-06-29');
 // Date objects
-date('error message', new Date('2000-12-30T00:00:00+0000'), new Date('2020-06-29T00:00:00+0000'));
+date('error message', new Date('2000-12-30T00:00:00+00:00'), new Date('2020-06-29T00:00:00+00:00'));
 
 /**
  * The value (date) must after the date.
@@ -476,7 +476,7 @@ date('error message', new Date('2000-12-30T00:00:00+0000'), new Date('2020-06-29
 // ISO string
 date('error message', '2000-12-30');
 // Date object
-date('error message', new Date('2000-12-30T00:00:00+0000'))
+date('error message', new Date('2000-12-30T00:00:00+00:00'))
 
 /**
  * The value (date) must before the date.
@@ -484,7 +484,7 @@ date('error message', new Date('2000-12-30T00:00:00+0000'))
 // ISO string
 date('error message', undefined|null, '2020-06-29');
 // Date object
-date('error message', undefined|null, new Date('2020-06-29T00:00:00+0000'))
+date('error message', undefined|null, new Date('2020-06-29T00:00:00+00:00'))
 
 /**
  * Relative offsets, relative to today.

--- a/src/rule/__test__/unit/date.test.ts
+++ b/src/rule/__test__/unit/date.test.ts
@@ -2,7 +2,7 @@ import date from '../../date'
 import {getToday, exported} from '../../date'
 
 describe('Validator - Rule - Date', () => {
-  const today = new Date('2000-12-30T00:00:00+0000')
+  const today = new Date('2000-12-30T00:00:00+00:00')
 
   // Get today in ISO, reset hours
   test('getToday', () => {
@@ -33,54 +33,54 @@ describe('Validator - Rule - Date', () => {
     // Future start
     {value: today, start: 1, end: undefined, expected: true},
     // Past end
-    {value: new Date('2000-12-29T00:00:00+0000'), start: undefined, end: -1, expected: true},
+    {value: new Date('2000-12-29T00:00:00+00:00'), start: undefined, end: -1, expected: true},
     // Specific past<->today
     {value: today, start: '2000-12-29', end: 0, expected: true},
     {
       value: today,
-      start: new Date('2000-12-29T00:00:00+0000'), end: 0,
+      start: new Date('2000-12-29T00:00:00+00:00'), end: 0,
       expected: true
     },
     // Today<->Specific future
     {value: today, start: 0, end: '2000-12-31', expected: true},
     {
       value: today,
-      start: 0, end: new Date('2000-12-31T00:00:00+0000'),
+      start: 0, end: new Date('2000-12-31T00:00:00+00:00'),
       expected: true
     },
     // Today<->+3days
     {
-      value: new Date('2001-01-01T00:00:00+0000'),
+      value: new Date('2001-01-01T00:00:00+00:00'),
       start: 0, end: '3d',
       expected: true
     },
     // Today<->+1week
     {
-      value: new Date('2001-01-01T00:00:00+0000'),
+      value: new Date('2001-01-01T00:00:00+00:00'),
       start: 0, end: '1w',
       expected: true
     },
     // Today<->+2months
     {
-      value: new Date('2001-01-01T00:00:00+0000'),
+      value: new Date('2001-01-01T00:00:00+00:00'),
       start: 0, end: '2m',
       expected: true
     },
     // Today<->+2years
     {
-      value: new Date('2001-01-01T00:00:00+0000'),
+      value: new Date('2001-01-01T00:00:00+00:00'),
       start: 0, end: '2y',
       expected: true
     },
     // Future start
     {
-      value: new Date('2001-01-05T00:00:00+0000'),
+      value: new Date('2001-01-05T00:00:00+00:00'),
       start: '3d', end: undefined,
       expected: true
     },
     // Past end
     {
-      value: new Date('2000-12-20T00:00:00+0000'),
+      value: new Date('2000-12-20T00:00:00+00:00'),
       start: -1, end: '-3d',
       expected: true
     },
@@ -91,48 +91,48 @@ describe('Validator - Rule - Date', () => {
     {value: today, start: '2000-12-31', end: 0, expected: 'invalid'},
     {
       value: today,
-      start: new Date('2000-12-31T00:00:00+0000'), end: 0,
+      start: new Date('2000-12-31T00:00:00+00:00'), end: 0,
       expected: 'invalid'
     },
     {value: today, start: 0, end: '2000-12-29', expected: 'invalid'},
     {
       value: today,
-      start: 0, end: new Date('2000-12-29T00:00:00+0000'),
+      start: 0, end: new Date('2000-12-29T00:00:00+00:00'),
       expected: 'invalid'
     },
     // Today<->no limit (future)
     {
-      value: new Date('2000-12-29T00:00:00+0000'),
+      value: new Date('2000-12-29T00:00:00+00:00'),
       start: 0, end: undefined,
       expected: 'invalid'
     },
     // no limit (past)<->Today
     {
-      value: new Date('2000-12-31T00:00:00+0000'),
+      value: new Date('2000-12-31T00:00:00+00:00'),
       start: undefined, end: 0,
       expected: 'invalid'
     },
     // Today<->+3days
     {
-      value: new Date('2001-01-03T00:00:00+0000'),
+      value: new Date('2001-01-03T00:00:00+00:00'),
       start: 0, end: '3d',
       expected: 'invalid'
     },
     // Today<->+1week
     {
-      value: new Date('2001-01-07T00:00:00+0000'),
+      value: new Date('2001-01-07T00:00:00+00:00'),
       start: 0, end: '1w',
       expected: 'invalid'
     },
     // Today<->+2months
     {
-      value: new Date('2000-03-01T00:00:00+0000'),
+      value: new Date('2000-03-01T00:00:00+00:00'),
       start: 0, end: '2m',
       expected: 'invalid'
     },
     // Today<->+2years
     {
-      value: new Date('2003-12-30T00:00:00+0000'),
+      value: new Date('2003-12-30T00:00:00+00:00'),
       start: 0, end: '2y',
       expected: 'invalid'
     },

--- a/src/rule/date.ts
+++ b/src/rule/date.ts
@@ -96,7 +96,7 @@ function dateBoundary (
     // Parse ISO date string if provided
     if ((filter as string).match(/^\d{4}-[0,1]\d-[0-3]\d$/)) {
       isDateFilter = true
-      filter = new Date(`${filter}T00:00:00+0000`)
+      filter = new Date(`${filter}T00:00:00+00:00`)
       if (isNaN(filter.getTime())) {
         throw new Error(`invalid "${filter}" ISO date string`)
       }
@@ -189,7 +189,7 @@ function date (
 
         // ISO format
       } else if (value.match(/^\d{4}-[0,1]\d-[0-3]\d$/)) {
-        value = new Date(`${value}T00:00:00+0000`)
+        value = new Date(`${value}T00:00:00+00:00`)
 
         // Invalid
       } else {


### PR DESCRIPTION
The date-time string format 'YYYY-MM-DDThh:mm:ss+**hhmm**' is not recognized by the safari browser. There should be a colon in the time-zone offset - 'YYYY-MM-DDThh:mm:ss+**hh:mm**' .
Verified that this format works in Safari, Chrome, Firefox.