### PR TITLE
Explicitly set local timezone offset when constructing a Date from an…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # wegood changelog
 
+## 1.0.6
+
+* Bug fix: re-instate timezone dependency, but local timezone offset instead.
+
 ## 1.0.5
 
 * Bug fix: remove timezone dependency.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briza/wegood",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Tiny validation library, so wegood with data.",
   "main": "lib/wegood.js",
   "module": "lib/wegood.esm.js",

--- a/src/rule/date.ts
+++ b/src/rule/date.ts
@@ -147,6 +147,24 @@ function dateBoundary (
 }
 
 /**
+ * Get local timezone offset as ISO string
+ * E.g. '-05:00'
+ * @return {string} ISO timezone offset string
+ */
+function getISOTimezoneOffset (): string {
+  function pad (value: number): string|number {
+    return value < 10 ? '0' + value : value
+  }
+
+  const date = new Date()
+  const sign = (date.getTimezoneOffset() > 0) ? '-' : '+'
+  const offset = Math.abs(date.getTimezoneOffset())
+  const hours = pad(Math.floor(offset / 60))
+  const minutes = pad(offset % 60)
+  return sign + hours + ':' + minutes
+}
+
+/**
  * Date validation rule.
  * The value passed into the validation function must be a Date object
  * or ISO date string: yyyy-mm-dd. Or a custom transform function can
@@ -192,7 +210,7 @@ function date (
 
         // ISO format
       } else if (value.match(/^\d{4}-[0,1]\d-[0-3]\d$/)) {
-        value = new Date(`${value}T00:00:00`)
+        value = new Date(`${value}T00:00:00${getISOTimezoneOffset()}`)
 
         // Invalid
       } else {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,7 +35,7 @@ export declare class Validator {
      * Get the validator rules.
      * @return {ValidationRule[]}
      */
-    readonly rules: ValidationRule[];
+    get rules(): ValidationRule[];
     /**
      * Validate against the value.
      * If all rules are satisfied, the return value is true.


### PR DESCRIPTION
… ISO-date string; fixes bug in Safari and possibly IE/Edge.  Should be net neutral for Chrome and Firefox.